### PR TITLE
docs/readthedocs.io

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/source/conf.py
+   configuration: docs/conf.py
 
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation


### PR DESCRIPTION
- Fix wrong filepath in .readthedocs.yaml.